### PR TITLE
Removed obsolete code

### DIFF
--- a/Src/Modules/SemVerPS/CS/SemVersion.cs
+++ b/Src/Modules/SemVerPS/CS/SemVersion.cs
@@ -28,7 +28,6 @@ using System;
 #if !NETSTANDARD
 using System.Globalization;
 using System.Runtime.Serialization;
-using System.Security.Permissions;
 #endif
 using System.Text.RegularExpressions;
 
@@ -476,7 +475,6 @@ namespace Semver
         }
 
 #if !NETSTANDARD
-        [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             if (info == null) throw new ArgumentNullException("info");


### PR DESCRIPTION
On .NET 5 `Import-Module` fails with:

```txt
/.local/share/powershell/Modules/SemVerPS/1.0/CS/SemVersion.cs(479,10): error CS0618: 'SecurityPermissionAttribute' is obsolete: 'Code Access Security is not supported or honored by
     | the runtime.'         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
```
Reference: https://github.com/dotnet/docs/issues/20894